### PR TITLE
UpdateChart call destoryChart() function unnecessary

### DIFF
--- a/app/components/ember-chart.js
+++ b/app/components/ember-chart.js
@@ -27,29 +27,29 @@ export default Ember.Component.extend({
 
   updateChart: function(){
     try {
-    	var self = this;
-    	this.get('data.datasets').forEach(function(dataset, i) {
-    		dataset.data.forEach(function(item, j) {
-				var chart = self.get('chart');
-			
-				if(typeof chart.datasets[i] === 'undefined') {
-					self.get('chart').segments[j].value = item;
-				} else {
-					var dataSet = self.get('chart').datasets[i];
-				
-					if(typeof dataSet.bars !== 'undefined') {
-						self.get('chart').datasets[i].bars[j].value = item;
-					} else {
-						self.get('chart').datasets[i].points[j].value = item;
-					}
-				}
-			});
-    	});
-    	this.get('chart').update();
+      var self = this;
+      this.get('data.datasets').forEach(function(dataset, i) {
+      	dataset.data.forEach(function(item, j) {
+	  var chart = self.get('chart');
+	  		
+	  if(typeof chart.datasets[i] === 'undefined') {
+	    self.get('chart').segments[j].value = item;
+	  } else {
+	    var dataSet = self.get('chart').datasets[i];
+	  
+	    if(typeof dataSet.bars !== 'undefined') {
+	      self.get('chart').datasets[i].bars[j].value = item;
+	    } else {
+	      self.get('chart').datasets[i].points[j].value = item;
+	    }
+	  }
+	});
+      });
+      this.get('chart').update();
     } catch(error) {
-    	Ember.warn('Dataset is not equal in structure as previous values. Rebuilding chart...');
-    	this.destroyChart();
-    	this.renderChart();
+      Ember.warn('Dataset is not equal in structure as previous values. Rebuilding chart...');
+      this.destroyChart();
+      this.renderChart();
     }
   }.observes('data', 'options')
 });


### PR DESCRIPTION
If an ember model is changed, the chart data has to update as well. This is done by destroying the chart + building a new one. I can see why this is done, as the structure of the data can change as well (by adding more or less data items).

But if the structure does not change, it's better to only update the values. All the items will be animated to the new value. Currently all the data is set to 0 and then the animation begins.
