### PR TITLE
Bug: legend is not removed if chart is destroyed

### DIFF
--- a/app/components/ember-chart.js
+++ b/app/components/ember-chart.js
@@ -22,6 +22,10 @@ export default Ember.Component.extend({
   }.on('didInsertElement'),
 
   destroyChart: function(){
+    if (this.get('legend')) {
+      this.$().parent().children('[class$=legend]').remove();
+    };
+    
     this.get('chart').destroy();
   }.on('willDestroyElement'),
 


### PR DESCRIPTION
Legend element is not removed if a chart is destroyed. This looks ugly if the labels do change (labels will be drawn apon each other).
