### PR TITLE
Update chart-data-updater.js to allow line charts to update

### DIFF
--- a/addon/chart-data-updater.js
+++ b/addon/chart-data-updater.js
@@ -18,8 +18,8 @@ export default Ember.Object.extend({
 
     if (chart.datasets.length !== datasets.length) {
       return this.set('redraw', true);
-    } else if (typeof chart.datasets[0].bars !== 'undefined') {
-      if (chart.datasets[0].bars.length !== datasets[0].data.length) {
+    } else if (typeof chart.datasets[0].points !== 'undefined') {
+      if (chart.datasets[0].points.length !== datasets[0].data.length) {
         return this.set('redraw', true);
       }
     }


### PR DESCRIPTION
This appears to be a bug in the logic (or some code was copy/pasted).  To update a line chart, we have to update the points, not the bars.  This fix works to update a chart if the number of data points change dynamically.  Please merge this!