### PR TITLE
Adds support for automatically updating the chart when the type changes

### DIFF
--- a/tests/unit/components/ember-chart-test.js
+++ b/tests/unit/components/ember-chart-test.js
@@ -406,3 +406,21 @@ test('it should rebuild line chart if data length within a set changes', functio
   chart = component.get('chart');
   assert.equal(chart.datasets[0].points.length, 7);
 });
+
+test('it should rebuild the chart (line -> bar) if the chart type changes', function(assert) {
+  var component = this.subject({
+    type: 'Line',
+    data: testData.get('lineData2')
+  });
+
+  this.render();
+  var chart = component.get('chart');
+  assert.equal(chart.datasets.length, 3);
+
+  // Update Type -- change to bar type
+  component.set('type', 'bar');
+
+  chart = component.get('chart');
+
+  assert.equal(chart.name, 'Bar');
+});


### PR DESCRIPTION
I found myself needing this for a project in which I'm using the `ember-cli-chart` library. It's great when you can create a chart using:

`{{ember-chart type=chartType data=chartData}}`

And have it automatically update when `chartData` changes. (Either due to an auto-update loop, or in response to user actions.) However, if one set of data is best viewed as a line chart and another set is better as a bar chart, it follows that changes to `chartType` should also trigger chart updates.

See it in action: https://vid.me/3ab0
