### PR TITLE
Add configurable lookup path for chart options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your handlebars template just do:
 ```
 
 * CHARTTYPE: String; one of the following -- `Line`, `Bar`, `Radar`, `PolarArea`, `Pie` or `Doughnut`.
-* CHARTDATA: Array; refer to the ChartJS documentation
+* CHARTDATA: Array or Object; refer to the ChartJS documentation
 * CHARTOPTIONS: Object; refer to the ChartJS documentation. This is optional.
 * CHARTWIDTH: Number; pixel width of the canvas element
 * CHARTHEIGHT: Number; pixel height of the canvas element

--- a/addon/components/ember-chart.js
+++ b/addon/components/ember-chart.js
@@ -9,6 +9,13 @@ export default Ember.Component.extend({
   lineLegendTemp: "<ul class=\"<%=name.toLowerCase()%>-legend\" style=\"list-style-type: none;\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].strokeColor%>;    width: 8px;height: 8px;display: inline-block;border-radius: 10px;border: solid;border-width: 2px;margin: 5px 5px 0 0;\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>",
   pieLegendTemp: "<ul class=\"<%=name.toLowerCase()%>-legend\" style=\"list-style-type: none;\"><% for (var i=0; i<segments.length; i++){%><li><span style=\"background-color:<%=segments[i].fillColor%>;  width: 8px;height: 8px;display: inline-block;border-radius: 10px;border: solid;border-width: 2px;margin: 5px 5px 0 0;\"></span><%if(segments[i].label){%><%=segments[i].label%><%}%></li><%}%></ul>",
 
+  /**
+   * This is where ember-chart will look to find the options to pass to the Chart.js chart.
+   * Subclasses may change this path to create a layer of indirection for the options, while
+   * preserving the same component API. This is useful if you want to extend this component to
+   * provide component-specific defaults in your own app.
+   */
+  optionsPath: 'options',
 
   didInsertElement: function(){
     var context = this.get('element').getContext('2d');
@@ -31,7 +38,7 @@ export default Ember.Component.extend({
     }
     var options = Ember.merge({
     legendTemplate : template
-    }, this.get('options'));
+    }, this.get(this.get('optionsPath')));
     var redraw = this.get('redraw');
     var chart = new Chart(context)[type](data, options);
 
@@ -44,7 +51,7 @@ export default Ember.Component.extend({
     this.set('chart', chart);
     this.addObserver('data', this, this.updateChart);
     this.addObserver('data.[]', this, this.updateChart);
-    this.addObserver('options', this, this.updateChart);
+    this.addObserver(this.get('optionsPath'), this, this.updateChart);
   },
 
   willDestroyElement: function(){
@@ -55,7 +62,7 @@ export default Ember.Component.extend({
     this.get('chart').destroy();
     this.removeObserver('data', this, this.updateChart);
     this.removeObserver('data.[]', this, this.updateChart);
-    this.removeObserver('options', this, this.updateChart);
+    this.removeObserver(this.get('optionsPath'), this, this.updateChart);
   },
 
   updateChart: function(){
@@ -79,4 +86,5 @@ export default Ember.Component.extend({
       this.$().parent().append(legend);
     }
   }
+
 });


### PR DESCRIPTION
Here's my use case:

I want to extend EmberChart to create individual components in my app with hardcoded defaults depending on the chart type, display options, etc.

At the moment, there's no way to do this without changing the API of those components (which would be confusing), since, as far as I know, there's no clean way to add a layer of indirection between the 'options' attr set on the component, and what EmberChart sees when it goes to render the chart.

By providing an 'optionsPath' option, I can change where EmberChart looks up the options, and create a computed property in my subclass at that path, like the following:

```
  optionsPath: 'modifiedOptions',

  modifiedOptions: Ember.computed('options', function() {
    const options = _.clone(this.get('options'));
    // Do something with the options passed in via the template...
    return options;
  }),
```
