### PR TITLE
Version 3: provide a wrapper for canvas since Chart.js hardly relies on parentNode

### DIFF
--- a/addon/components/ember-chart.js
+++ b/addon/components/ember-chart.js
@@ -2,11 +2,8 @@ import Ember from 'ember';
 /* global Chart */
 
 export default Ember.Component.extend({
-  tagName: 'canvas',
-  attributeBindings: ['width', 'height'],
-
   didInsertElement: function(){
-    var context = this.get('element');
+    var context = this.$('canvas').first();
     var data    = this.get('data');
     var type    = this.get('type');
     var options = this.get('options');

--- a/app/templates/components/ember-chart.hbs
+++ b/app/templates/components/ember-chart.hbs
@@ -1,0 +1,1 @@
+<canvas width={{width}} height={{height}}></canvas>


### PR DESCRIPTION
Chart.js adds a hidden iframe to parentNode in `helpers.addResizeListener` method and calculates maximum width / height depending on styles of parent node in `helpers.getMaximumWidth` and `getMaximumHeight` methods.

In Microsoft edge there are cases (propably connected to destroy) in which `parentNode` is `null` and therefore chart.js throws an error `Unable to get property 'currentStyle' of undefined or null` in `getStyle` method called by `getMaximumWidth` and `getMaximumHeight`.

Related to: https://github.com/aomran/ember-cli-chart/pull/54#issuecomment-239636751
