### PR TITLE
fix pie chart update when data changes

### DIFF
--- a/addon/chart-data-updater.js
+++ b/addon/chart-data-updater.js
@@ -66,20 +66,9 @@ export default Ember.Object.extend({
     var chart = this.get('chart');
     var chartSegments = Ember.A(chart.segments);
 
-    chart.segments.forEach(function(segment, i) {
-      var updatedSegment = data.findBy('label', segment.label);
-      if (updatedSegment) {
-        // Same segment exists in new data
-        chart.segments[i].value = updatedSegment.value || 0;
-
-        // Update label
-        chart.segments[i].label = updatedSegment.label || '';
-
-      } else {
-        // Segment does not exist anymore in new data
-        chart.removeData(i);
-      }
-    });
+    while (chart.segments.length) {
+        chart.removeData();
+    }
 
     data.forEach(function(segment) {
       var currentSegment = chartSegments.findBy('label', segment.label);

--- a/tests/unit/components/ember-chart-test.js
+++ b/tests/unit/components/ember-chart-test.js
@@ -59,6 +59,53 @@ var ChartTestData = Ember.Object.extend({
     ];
   }),
 
+  pieData3: Ember.computed(function(){
+    return [
+      {
+        value: 50,
+        color: "#000000",
+        highlight: "#000000",
+        label: "Black"
+      },
+      {
+        value: 100,
+        color:"#F7464A",
+        highlight: "#FF5A5E",
+        label: "Red"
+      },
+      {
+        value: 101,
+        color: "#FDB45C",
+        highlight: "#FFC870",
+        label: "Yellow"
+      },
+      {
+        value: 200,
+        color: "#FDB45C",
+        highlight: "#FFC870",
+        label: "Blue"
+      },
+      {
+        value: 300,
+        color: "#FDB45C",
+        highlight: "#FFC870",
+        label: "White"
+      },
+      {
+        value: 75,
+        color: "#FDB45C",
+        highlight: "#FFC870",
+        label: "Brown"
+      },
+      {
+        value: 65,
+        color: "#FDB45C",
+        highlight: "#FFC870",
+        label: "Pink"
+      }
+    ];
+  }),
+
   labelValue1: "January",
   lineValue1: 65,
   lineValue2: 59,
@@ -328,6 +375,26 @@ test('it should update pie chart if data structure changes', function(assert) {
   var component = this.subject({
     type: 'Pie',
     data: testData.get('pieData')
+  });
+
+  this.render();
+
+  // Update Data
+  component.set('data', testData.get('pieData2'));
+
+  var chart = component.get('chart');
+  var segments = Ember.A(chart.segments);
+
+  assert.equal(segments.findBy('label', 'Red').value, 310);
+  assert.equal(segments.findBy('label', 'Yellow').value, 101);
+  assert.equal(segments.findBy('label', 'Black').value, 20);
+  assert.equal(segments.length, 3);
+});
+
+test('it should update pie chart if data quantity changes', function(assert) {
+  var component = this.subject({
+    type: 'Pie',
+    data: testData.get('pieData3')
   });
 
   this.render();


### PR DESCRIPTION
There is a problem when pie chart data updates. If new data length is less than old one, some old chart segment could be not removed. Because in updatePieCharts function chart.segments removed in the forEach loop. Also new data could have wrong order. 
I think it is better just to remove all old data before.
