### PR TITLE
Remove blueprint

### DIFF
--- a/blueprints/ember-cli-chart/index.js
+++ b/blueprints/ember-cli-chart/index.js
@@ -1,7 +1,0 @@
-module.exports = {
-  normalizeEntityName: function() {},
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('chartjs', '2.5.0');
-  }
-};


### PR DESCRIPTION
We don't need to add the bower package if we're no longer using it.