### PR TITLE
Only require customLegendElement

### DIFF
--- a/addon/components/ember-chart.js
+++ b/addon/components/ember-chart.js
@@ -55,7 +55,7 @@ export default Component.extend({
         chart.update(0);
       }
 
-      if (options.legendCallback && this.customLegendElement) {
+      if (this.customLegendElement) {
         this.customLegendElement.innerHTML = chart.generateLegend();
       }
     }


### PR DESCRIPTION
This fixes an issue where you could use the built in generateLabels, and might not be supplying the `legendCallback`.