### PR TITLE
Update to ChartJS 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/aomran/ember-cli-chart.svg)](https://travis-ci.org/aomran/ember-cli-chart)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-cli-chart.svg)](https://emberobserver.com/addons/ember-cli-chart)
 
-This Ember CLI addon is a simple wrapper for [ChartJS](http://www.chartjs.org/) (v2.9).
+This Ember CLI addon is a simple wrapper for [ChartJS](http://www.chartjs.org/) (v3.5).
 
 ### Compatibility
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
     'chart.js': {
       vendor: {
           srcDir: 'dist',
-          include: ['Chart.js'],
+          include: ['chart.js'],
           processTree(input) {
             return FastbootTransform(input);
           }
@@ -21,7 +21,7 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this._ensureThisImport();
 
-    this.import('vendor/chart.js/Chart.js');
+    this.import('vendor/chart.js/chart.js');
   },
   _ensureThisImport() {
     if (!this.import) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
-    "chart.js": "^2.9.0",
+    "chart.js": "^3.5.0",
     "ember-cli-babel": "^7.20.5",
     "ember-cli-htmlbars": "^5.1.2",
     "ember-cli-node-assets": "^0.2.2",


### PR DESCRIPTION
Closes #127

Supersedes PR #136 

See previous PR for background, but basically only updates ChartJS rather than also trying to sort out the `chart-chartjs-financial` dependency. That will be dealt with in a separate PR.